### PR TITLE
PP9-5408: add sort attribute and adjust analyzer attribute

### DIFF
--- a/src/Picturepark.SDK.V1.Contract/Attributes/Analyzer/PictureparkAnalyzerAttribute.cs
+++ b/src/Picturepark.SDK.V1.Contract/Attributes/Analyzer/PictureparkAnalyzerAttribute.cs
@@ -6,6 +6,8 @@ namespace Picturepark.SDK.V1.Contract.Attributes.Analyzer
     {
         public bool SimpleSearch { get; set; }
 
+        public bool Index { get; set; }
+
         /// <summary>Creates an analyzer based on the attribute.</summary>
         /// <returns>The analyzer.</returns>
         public abstract AnalyzerBase CreateAnalyzer();

--- a/src/Picturepark.SDK.V1.Contract/Attributes/PictureparkMaximumRecursionAttribute.cs
+++ b/src/Picturepark.SDK.V1.Contract/Attributes/PictureparkMaximumRecursionAttribute.cs
@@ -1,9 +1,0 @@
-﻿using System;
-
-namespace Picturepark.SDK.V1.Contract.Attributes
-{
-	public class PictureparkMaximumRecursionAttribute : Attribute, IPictureparkAttribute
-	{
-		public int MaxRecursion { get; set; }
-	}
-}

--- a/src/Picturepark.SDK.V1.Contract/Attributes/PictureparkSortAttribute.cs
+++ b/src/Picturepark.SDK.V1.Contract/Attributes/PictureparkSortAttribute.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Picturepark.SDK.V1.Contract.Attributes
+{
+    [AttributeUsage(AttributeTargets.All)]
+    public class PictureparkSortAttribute : Attribute, IPictureparkAttribute
+    {
+    }
+}

--- a/src/Picturepark.SDK.V1.Tests/AnalyzerTests.cs
+++ b/src/Picturepark.SDK.V1.Tests/AnalyzerTests.cs
@@ -111,19 +111,19 @@ namespace Picturepark.SDK.V1.Tests
         [PictureparkSchemaType(SchemaType.List)]
         public class AnalyzerTestObject
         {
-            [PictureparkEdgeNGramAnalyzer]
+            [PictureparkEdgeNGramAnalyzer(Index = true)]
             public string EdgeNGramField { get; set; }
 
-            [PictureparkNGramAnalyzer]
+            [PictureparkNGramAnalyzer(Index = true)]
             public string NGramField { get; set; }
 
-            [PictureparkPathHierarchyAnalyzer]
+            [PictureparkPathHierarchyAnalyzer(Index = true)]
             public string PathHierarchyField { get; set; }
 
-            [PictureparkSimpleAnalyzer]
+            [PictureparkSimpleAnalyzer(Index = true)]
             public string SimpleField { get; set; }
 
-            [PictureparkLanguageAnalyzer]
+            [PictureparkLanguageAnalyzer(Index = true)]
             public TranslatedStringDictionary LanguageField { get; set; }
         }
     }

--- a/src/Picturepark.SDK.V1.Tests/Contracts/Person.cs
+++ b/src/Picturepark.SDK.V1.Tests/Contracts/Person.cs
@@ -39,11 +39,9 @@ namespace Picturepark.SDK.V1.Tests.Contracts
 
 		// Usage for recursions
 		[PictureparkSearch(Index = true, SimpleSearch = true, Boost = 10)]
-		[PictureparkMaximumRecursion(MaxRecursion = 2)]
 		public Person Child { get; set; }
 
 		[PictureparkSearch(Index = true, SimpleSearch = true, Boost = 10)]
-		[PictureparkMaximumRecursion(MaxRecursion = 3)]
 		public List<Person> Siblings { get; set; }
 	}
 


### PR DESCRIPTION
- add new PictureparkSortAttribute to mark a field as sortable
- adjust PictureparkAnalyzerAttribute to have both a property for indexing and simple search (one of these must be set)
- remove obsolete PictureparkMaxRecursionAttribute
- Add tests for the new attributes, and the new behavior of the analyzer attribute