### PR TITLE
Add netstandard2.0 target framework

### DIFF
--- a/src/Picturepark.SDK.V1.CloudManager/Picturepark.SDK.V1.CloudManager.csproj
+++ b/src/Picturepark.SDK.V1.CloudManager/Picturepark.SDK.V1.CloudManager.csproj
@@ -1,36 +1,33 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<Description>Picturepark .NET SDK CloudManager: Manage Picturepark backend instances.</Description>
-		<AssemblyTitle>Picturepark.SDK.V1.CloudManager</AssemblyTitle>
-    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+  <PropertyGroup>
+    <Description>Picturepark .NET SDK CloudManager: Manage Picturepark backend instances.</Description>
+    <AssemblyTitle>Picturepark.SDK.V1.CloudManager</AssemblyTitle>
+    <TargetFrameworks>netstandard1.3;net45;netstandard2.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591;SA1600;SA1601</NoWarn>
-		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<AssemblyName>Picturepark.SDK.V1.CloudManager</AssemblyName>
-		<PackageId>Picturepark.SDK.V1.CloudManager</PackageId>
-		<PackageIconUrl>https://bitbucket.vit.ch:8443/projects/PP9/repos/picturepark.public/browse/picturepark-240px.png?raw</PackageIconUrl>
-		<PackageLicenseUrl>https://github.com/Picturepark/Picturepark.SDK.DotNet/blob/master/LICENSE.md</PackageLicenseUrl>
-		<GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
-		<GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-		<GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-		<CodeAnalysisRuleSet>../Picturepark.SDK.DotNet.ruleset</CodeAnalysisRuleSet>
-		<Version>0.0.0</Version>
-		<PackageProjectUrl>https://github.com/Picturepark/Picturepark.SDK.DotNet</PackageProjectUrl>
-	</PropertyGroup>
-
-	<ItemGroup>
-		<ProjectReference Include="..\Picturepark.SDK.V1.Contract\Picturepark.SDK.V1.Contract.csproj" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-	  <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.23">
-	    <PrivateAssets>All</PrivateAssets>
-	  </PackageReference>
-		<PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
-			<PrivateAssets>All</PrivateAssets>
-		</PackageReference>
-	</ItemGroup>
-
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AssemblyName>Picturepark.SDK.V1.CloudManager</AssemblyName>
+    <PackageId>Picturepark.SDK.V1.CloudManager</PackageId>
+    <PackageIconUrl>https://bitbucket.vit.ch:8443/projects/PP9/repos/picturepark.public/browse/picturepark-240px.png?raw</PackageIconUrl>
+    <PackageLicenseUrl>https://github.com/Picturepark/Picturepark.SDK.DotNet/blob/master/LICENSE.md</PackageLicenseUrl>
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <CodeAnalysisRuleSet>../Picturepark.SDK.DotNet.ruleset</CodeAnalysisRuleSet>
+    <Version>0.0.0</Version>
+    <PackageProjectUrl>https://github.com/Picturepark/Picturepark.SDK.DotNet</PackageProjectUrl>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Picturepark.SDK.V1.Contract\Picturepark.SDK.V1.Contract.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.23">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="System.Runtime" Version="4.3.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.4.0" />
@@ -44,7 +41,6 @@
     <PackageReference Include="System.Collections" Version="4.3.0" />
     <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
   </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <PackageReference Include="System.Net.Http" Version="4.1.1" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/src/Picturepark.SDK.V1.Contract/Picturepark.SDK.V1.Contract.csproj
+++ b/src/Picturepark.SDK.V1.Contract/Picturepark.SDK.V1.Contract.csproj
@@ -1,42 +1,39 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<Description>Picturepark .NET SDK Contracts: The SDK's contracts (DTOs and client interfaces).</Description>
-		<AssemblyTitle>Picturepark.SDK.V1.Contract</AssemblyTitle>
-		<TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
-		<NoWarn>$(NoWarn);CS1591;SA1600;SA1601</NoWarn>
-		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<AssemblyName>Picturepark.SDK.V1.Contract</AssemblyName>
-		<PackageId>Picturepark.SDK.V1.Contract</PackageId>
-		<PackageIconUrl>https://bitbucket.vit.ch:8443/projects/PP9/repos/picturepark.public/browse/picturepark-240px.png?raw</PackageIconUrl>
-		<PackageLicenseUrl>https://github.com/Picturepark/Picturepark.SDK.DotNet/blob/master/LICENSE.md</PackageLicenseUrl>
-		<GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
-		<GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-		<GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-		<CodeAnalysisRuleSet>../Picturepark.SDK.DotNet.ruleset</CodeAnalysisRuleSet>
-		<Version>0.0.0</Version>
-		<PackageProjectUrl>https://github.com/Picturepark/Picturepark.SDK.DotNet</PackageProjectUrl>
-	</PropertyGroup>
-
-	<ItemGroup>
-		<PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-	  <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.23">
-	    <PrivateAssets>All</PrivateAssets>
-	  </PackageReference>
-		<PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
-			<PrivateAssets>All</PrivateAssets>
-		</PackageReference>
-		<PackageReference Include="System.ValueTuple" Version="4.4.0" />
-	</ItemGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-		<PackageReference Include="System.Diagnostics.Tools" Version="4.3.0.0" />
-		<PackageReference Include="System.ComponentModel.Annotations" Version="4.4.0" />
-	</ItemGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-		<Reference Include="System.ComponentModel.DataAnnotations" />
-		<Reference Include="System.Runtime.Serialization" />
-		<Reference Include="System" />
-		<Reference Include="Microsoft.CSharp" />
-	</ItemGroup>
+  <PropertyGroup>
+    <Description>Picturepark .NET SDK Contracts: The SDK's contracts (DTOs and client interfaces).</Description>
+    <AssemblyTitle>Picturepark.SDK.V1.Contract</AssemblyTitle>
+    <TargetFrameworks>netstandard1.3;net45;netstandard2.0</TargetFrameworks>
+    <NoWarn>$(NoWarn);CS1591;SA1600;SA1601</NoWarn>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AssemblyName>Picturepark.SDK.V1.Contract</AssemblyName>
+    <PackageId>Picturepark.SDK.V1.Contract</PackageId>
+    <PackageIconUrl>https://bitbucket.vit.ch:8443/projects/PP9/repos/picturepark.public/browse/picturepark-240px.png?raw</PackageIconUrl>
+    <PackageLicenseUrl>https://github.com/Picturepark/Picturepark.SDK.DotNet/blob/master/LICENSE.md</PackageLicenseUrl>
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <CodeAnalysisRuleSet>../Picturepark.SDK.DotNet.ruleset</CodeAnalysisRuleSet>
+    <Version>0.0.0</Version>
+    <PackageProjectUrl>https://github.com/Picturepark/Picturepark.SDK.DotNet</PackageProjectUrl>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.23">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <PackageReference Include="System.Diagnostics.Tools" Version="4.3.0.0" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.4.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
 </Project>

--- a/src/Picturepark.SDK.V1.Contract/Picturepark.SDK.V1.Contract.csproj
+++ b/src/Picturepark.SDK.V1.Contract/Picturepark.SDK.V1.Contract.csproj
@@ -30,6 +30,9 @@
     <PackageReference Include="System.Diagnostics.Tools" Version="4.3.0.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.4.0" />
   </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.4.0" />
+  </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Runtime.Serialization" />

--- a/src/Picturepark.SDK.V1.Localization/Picturepark.SDK.V1.Localization.csproj
+++ b/src/Picturepark.SDK.V1.Localization/Picturepark.SDK.V1.Localization.csproj
@@ -1,48 +1,45 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<Description>Picturepark .NET SDK Localization: Provides translations for exception codes and texts.</Description>
-		<AssemblyTitle>Picturepark.SDK.V1.Localization</AssemblyTitle>
-		<TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
-		<NoWarn>$(NoWarn);CS1591;SA1600;SA1601</NoWarn>
-		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<AssemblyName>Picturepark.SDK.V1.Localization</AssemblyName>
-		<PackageId>Picturepark.SDK.V1.Localization</PackageId>
-		<PackageIconUrl>https://bitbucket.vit.ch:8443/projects/PP9/repos/picturepark.public/browse/picturepark-240px.png?raw</PackageIconUrl>
-		<PackageLicenseUrl>https://github.com/Picturepark/Picturepark.SDK.DotNet/blob/master/LICENSE.md</PackageLicenseUrl>
-		<GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
-		<GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-		<GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-		<CodeAnalysisRuleSet>../Picturepark.SDK.DotNet.ruleset</CodeAnalysisRuleSet>
-		<Version>0.0.0</Version>
-		<PackageProjectUrl>https://github.com/Picturepark/Picturepark.SDK.DotNet</PackageProjectUrl>
-	</PropertyGroup>
-	<ItemGroup>
-	  <None Remove="Languages\de.mo" />
-	  <None Remove="Languages\en.mo" />
-	</ItemGroup>
-	<ItemGroup>
-	  <EmbeddedResource Include="Languages\de.mo" />
-	  <EmbeddedResource Include="Languages\en.mo" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<ProjectReference Include="..\Picturepark.SDK.V1.Contract\Picturepark.SDK.V1.Contract.csproj" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<PackageReference Include="DotLiquid" Version="2.0.298" />
-		<PackageReference Include="NGettext" Version="0.6.3" />
-		<PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
-	  <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.23">
-	    <PrivateAssets>All</PrivateAssets>
-	  </PackageReference>
-		<PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
-			<PrivateAssets>All</PrivateAssets>
-		</PackageReference>
-	</ItemGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
-		<Reference Include="System" />
-		<Reference Include="Microsoft.CSharp" />
-	</ItemGroup>
+  <PropertyGroup>
+    <Description>Picturepark .NET SDK Localization: Provides translations for exception codes and texts.</Description>
+    <AssemblyTitle>Picturepark.SDK.V1.Localization</AssemblyTitle>
+    <TargetFrameworks>netstandard1.3;net45;netstandard2.0</TargetFrameworks>
+    <NoWarn>$(NoWarn);CS1591;SA1600;SA1601</NoWarn>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AssemblyName>Picturepark.SDK.V1.Localization</AssemblyName>
+    <PackageId>Picturepark.SDK.V1.Localization</PackageId>
+    <PackageIconUrl>https://bitbucket.vit.ch:8443/projects/PP9/repos/picturepark.public/browse/picturepark-240px.png?raw</PackageIconUrl>
+    <PackageLicenseUrl>https://github.com/Picturepark/Picturepark.SDK.DotNet/blob/master/LICENSE.md</PackageLicenseUrl>
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <CodeAnalysisRuleSet>../Picturepark.SDK.DotNet.ruleset</CodeAnalysisRuleSet>
+    <Version>0.0.0</Version>
+    <PackageProjectUrl>https://github.com/Picturepark/Picturepark.SDK.DotNet</PackageProjectUrl>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Remove="Languages\de.mo" />
+    <None Remove="Languages\en.mo" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Languages\de.mo" />
+    <EmbeddedResource Include="Languages\en.mo" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Picturepark.SDK.V1.Contract\Picturepark.SDK.V1.Contract.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="DotLiquid" Version="2.0.298" />
+    <PackageReference Include="NGettext" Version="0.6.3" />
+    <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.23">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
 </Project>

--- a/src/Picturepark.SDK.V1.ServiceProvider/Picturepark.SDK.V1.ServiceProvider.csproj
+++ b/src/Picturepark.SDK.V1.ServiceProvider/Picturepark.SDK.V1.ServiceProvider.csproj
@@ -1,45 +1,41 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<Description>Picturepark .NET SDK ServiceProvider</Description>
-		<AssemblyTitle>Picturepark.SDK.V1.ServiceProvider</AssemblyTitle>
-		<TargetFrameworks>netstandard1.6;net46</TargetFrameworks>
-		<NoWarn>$(NoWarn);CS1591;SA1600;SA1601</NoWarn>
-		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<AssemblyName>Picturepark.SDK.V1.ServiceProvider</AssemblyName>
-		<PackageId>Picturepark.SDK.V1.ServiceProvider</PackageId>
-		<PackageIconUrl>https://bitbucket.vit.ch:8443/projects/PP9/repos/picturepark.public/browse/picturepark-240px.png?raw</PackageIconUrl>
-		<PackageLicenseUrl>https://github.com/Picturepark/Picturepark.SDK.DotNet/blob/master/LICENSE.md</PackageLicenseUrl>
-		<GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
-		<GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-		<GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-		<CodeAnalysisRuleSet>../Picturepark.SDK.DotNet.ruleset</CodeAnalysisRuleSet>
-		<Version>0.0.0</Version>
-		<PackageProjectUrl>https://github.com/Picturepark/Picturepark.SDK.DotNet</PackageProjectUrl>
-	</PropertyGroup>
-
-	<ItemGroup>
-		<PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-		<PackageReference Include="RabbitMQ.Client" Version="5.0.1" />
-		<PackageReference Include="System.Reactive.Linq" Version="3.1.1" />
-	  <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.23">
-	    <PrivateAssets>All</PrivateAssets>
-	  </PackageReference>
-		<PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
-			<PrivateAssets>All</PrivateAssets>
-		</PackageReference>
-	</ItemGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
-		<PackageReference Include="System.ComponentModel.Annotations" Version="4.4.0" />
-	</ItemGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-		<Reference Include="System" />
-		<Reference Include="Microsoft.CSharp" />
-		<Reference Include="System.ComponentModel.DataAnnotations" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <ProjectReference Include="..\Picturepark.SDK.V1.Contract\Picturepark.SDK.V1.Contract.csproj" />
-	</ItemGroup>
+  <PropertyGroup>
+    <Description>Picturepark .NET SDK ServiceProvider</Description>
+    <AssemblyTitle>Picturepark.SDK.V1.ServiceProvider</AssemblyTitle>
+    <TargetFrameworks>netstandard1.6;net46;netstandard2.0</TargetFrameworks>
+    <NoWarn>$(NoWarn);CS1591;SA1600;SA1601</NoWarn>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AssemblyName>Picturepark.SDK.V1.ServiceProvider</AssemblyName>
+    <PackageId>Picturepark.SDK.V1.ServiceProvider</PackageId>
+    <PackageIconUrl>https://bitbucket.vit.ch:8443/projects/PP9/repos/picturepark.public/browse/picturepark-240px.png?raw</PackageIconUrl>
+    <PackageLicenseUrl>https://github.com/Picturepark/Picturepark.SDK.DotNet/blob/master/LICENSE.md</PackageLicenseUrl>
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <CodeAnalysisRuleSet>../Picturepark.SDK.DotNet.ruleset</CodeAnalysisRuleSet>
+    <Version>0.0.0</Version>
+    <PackageProjectUrl>https://github.com/Picturepark/Picturepark.SDK.DotNet</PackageProjectUrl>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="RabbitMQ.Client" Version="5.0.1" />
+    <PackageReference Include="System.Reactive.Linq" Version="3.1.1" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.23">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.4.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Picturepark.SDK.V1.Contract\Picturepark.SDK.V1.Contract.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Picturepark.SDK.V1/Picturepark.SDK.V1.csproj
+++ b/src/Picturepark.SDK.V1/Picturepark.SDK.V1.csproj
@@ -1,55 +1,51 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<Description>Picturepark .NET SDK: The client implementations to access the Picturepark backend.</Description>
-		<AssemblyTitle>Picturepark.SDK.V1</AssemblyTitle>
-		<TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
-		<NoWarn>$(NoWarn);CS1591;SA1600;SA1601</NoWarn>
-		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<AssemblyName>Picturepark.SDK.V1</AssemblyName>
-		<PackageId>Picturepark.SDK.V1</PackageId>
-		<PackageIconUrl>https://bitbucket.vit.ch:8443/projects/PP9/repos/picturepark.public/browse/picturepark-240px.png?raw</PackageIconUrl>
-		<PackageLicenseUrl>https://github.com/Picturepark/Picturepark.SDK.DotNet/blob/master/LICENSE.md</PackageLicenseUrl>
-		<GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
-		<GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-		<GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-		<CodeAnalysisRuleSet>../Picturepark.SDK.DotNet.ruleset</CodeAnalysisRuleSet>
-		<Version>0.0.0</Version>
-		<PackageProjectUrl>https://github.com/Picturepark/Picturepark.SDK.DotNet</PackageProjectUrl>
-	</PropertyGroup>
-
-	<ItemGroup>
-		<ProjectReference Include="..\Picturepark.SDK.V1.Contract\Picturepark.SDK.V1.Contract.csproj" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<PackageReference Include="Microsoft.Net.Http.Headers" Version="1.0.0" />
-		<PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-		<PackageReference Include="Nerdbank.GitVersioning" Version="2.1.23">
-			<PrivateAssets>All</PrivateAssets>
-		</PackageReference>
-		<PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
-			<PrivateAssets>All</PrivateAssets>
-		</PackageReference>
-	</ItemGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-		<PackageReference Include="System.Runtime" Version="4.3.0" />
-		<PackageReference Include="System.ComponentModel.Annotations" Version="4.4.0" />
-		<PackageReference Include="System.Threading" Version="4.3.0" />
-		<PackageReference Include="System.Threading.Tasks" Version="4.3.0" />
-		<PackageReference Include="System.Threading.Timer" Version="4.3.0" />
-		<PackageReference Include="System.Net.Primitives" Version="4.3.0" />
-		<PackageReference Include="System.IO" Version="4.3.0" />
-		<PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
-		<PackageReference Include="System.Net.Http" Version="4.3.0" />
-		<PackageReference Include="System.Collections" Version="4.3.0" />
-		<PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
-	</ItemGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-		<PackageReference Include="System.Net.Http" Version="4.1.1" />
-		<Reference Include="System.ComponentModel.DataAnnotations" />
-		<Reference Include="System" />
-		<Reference Include="Microsoft.CSharp" />
-	</ItemGroup>
+  <PropertyGroup>
+    <Description>Picturepark .NET SDK: The client implementations to access the Picturepark backend.</Description>
+    <AssemblyTitle>Picturepark.SDK.V1</AssemblyTitle>
+    <TargetFrameworks>netstandard1.3;net45;netstandard2.0</TargetFrameworks>
+    <NoWarn>$(NoWarn);CS1591;SA1600;SA1601</NoWarn>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AssemblyName>Picturepark.SDK.V1</AssemblyName>
+    <PackageId>Picturepark.SDK.V1</PackageId>
+    <PackageIconUrl>https://bitbucket.vit.ch:8443/projects/PP9/repos/picturepark.public/browse/picturepark-240px.png?raw</PackageIconUrl>
+    <PackageLicenseUrl>https://github.com/Picturepark/Picturepark.SDK.DotNet/blob/master/LICENSE.md</PackageLicenseUrl>
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <CodeAnalysisRuleSet>../Picturepark.SDK.DotNet.ruleset</CodeAnalysisRuleSet>
+    <Version>0.0.0</Version>
+    <PackageProjectUrl>https://github.com/Picturepark/Picturepark.SDK.DotNet</PackageProjectUrl>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Picturepark.SDK.V1.Contract\Picturepark.SDK.V1.Contract.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Net.Http.Headers" Version="1.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.23">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <PackageReference Include="System.Runtime" Version="4.3.0" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.4.0" />
+    <PackageReference Include="System.Threading" Version="4.3.0" />
+    <PackageReference Include="System.Threading.Tasks" Version="4.3.0" />
+    <PackageReference Include="System.Threading.Timer" Version="4.3.0" />
+    <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.IO" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.0" />
+    <PackageReference Include="System.Collections" Version="4.3.0" />
+    <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+    <PackageReference Include="System.Net.Http" Version="4.1.1" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Add .NET Standard 2.0 target framework (best practice for library projects to avoid legacy System.* dependencies). 

Closes #171

FYI: Migration was done with 

    dnt add-target-framework netstandard2.0

https://github.com/RSuter/DNT#add-target-framework

To diff this PR, use "Diff settings" > "Hide whitespace changes"