### PR TITLE
add metadata item lifecycle to search response 

### DIFF
--- a/src/Picturepark.SDK.V1.Contract/Contracts.Generated.cs
+++ b/src/Picturepark.SDK.V1.Contract/Contracts.Generated.cs
@@ -14623,6 +14623,11 @@ namespace Picturepark.SDK.V1.Contract
         [Newtonsoft.Json.JsonProperty("brokenRelationTargetIds", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.ICollection<string> BrokenRelationTargetIds { get; set; }
     
+        /// <summary>Life cycle of content</summary>
+        [Newtonsoft.Json.JsonProperty("lifeCycle", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public LifeCycle LifeCycle { get; set; }
+    
         public string ToJson() 
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
@@ -16000,6 +16005,11 @@ namespace Picturepark.SDK.V1.Contract
         /// <summary>All the ids of the broken indirect references (tagbox that has a property that reference a broken tagbox)</summary>
         [Newtonsoft.Json.JsonProperty("brokenIndirectReferenceIds", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.ICollection<string> BrokenIndirectReferenceIds { get; set; }
+    
+        /// <summary>LifeCycle of list item</summary>
+        [Newtonsoft.Json.JsonProperty("lifeCycle", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public LifeCycle LifeCycle { get; set; }
     
         public string ToJson() 
         {

--- a/src/Picturepark.SDK.V1.Tests/Clients/ContentTests.cs
+++ b/src/Picturepark.SDK.V1.Tests/Clients/ContentTests.cs
@@ -1088,7 +1088,8 @@ namespace Picturepark.SDK.V1.Tests.Clients
             ContentSearchResult result = await _client.Content.SearchAsync(request).ConfigureAwait(false);
 
             // Assert
-            Assert.True(result.Results.Count > 0);
+            result.Results.Count.Should().BeGreaterThan(0);
+            result.Results.First().LifeCycle.Should().Be(LifeCycle.Active);
         }
 
         [Fact]

--- a/src/Picturepark.SDK.V1.Tests/Clients/ListItemTests.cs
+++ b/src/Picturepark.SDK.V1.Tests/Clients/ListItemTests.cs
@@ -511,6 +511,8 @@ namespace Picturepark.SDK.V1.Tests.Clients
             // Assert
             Assert.True(!failedMetadataSchemaIds.Any());
             Assert.True(items.Any());
+
+            items.First().LifeCycle.Should().Be(LifeCycle.Active);
         }
 
         [Fact]

--- a/swagger/PictureparkSwagger.json
+++ b/swagger/PictureparkSwagger.json
@@ -29583,6 +29583,14 @@
             "items": {
               "type": "string"
             }
+          },
+          "lifeCycle": {
+            "description": "Life cycle of content",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/LifeCycle"
+              }
+            ]
           }
         }
       },
@@ -30981,6 +30989,14 @@
             "items": {
               "type": "string"
             }
+          },
+          "lifeCycle": {
+            "description": "LifeCycle of list item",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/LifeCycle"
+              }
+            ]
           }
         }
       },


### PR DESCRIPTION
- regenerate for new property in view items for contents and list items
- extend tests to check lifecycle