### PR TITLE
PP9-20278 use Net60 runtime for nswag, same as in backend solution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "nswag": "nswag run \"src/Picturepark.SDK.V1/nswag.json\" && nswag run \"src/Picturepark.SDK.V1.CloudManager/nswag.json\"",
+    "nswag": "nswag run \"src/Picturepark.SDK.V1/nswag.json\" /runtime:Net60 && nswag run \"src/Picturepark.SDK.V1.CloudManager/nswag.json\" /runtime:Net60",
     "docs": "call \"build/04_BuildDocs.bat\"",
     "tests": "PowerShell -File \"build/02_RunTests.ps1\"",
     "build": "call \"build/01_BuildAndCreatePackages\" && npm run docs"


### PR DESCRIPTION
without this change it wants .net 7