### PR TITLE
PP9-12207 revert deprecation of Picturepark.SDK.V1.ServiceProvider.Co…

### DIFF
--- a/src/Picturepark.SDK.V1.ServiceProvider/Common/Configuration.cs
+++ b/src/Picturepark.SDK.V1.ServiceProvider/Common/Configuration.cs
@@ -27,7 +27,6 @@ namespace Picturepark.SDK.V1.ServiceProvider
 
         public string ServiceProviderId { get; set; }
 
-        [Obsolete("NodeId will be removed in a future release")]
         public string NodeId { get; set; }
 
         public JsonSerializerSettings SerializerSettings { get; set; }

--- a/src/Picturepark.SDK.V1.ServiceProvider/ServiceProviderClient.cs
+++ b/src/Picturepark.SDK.V1.ServiceProvider/ServiceProviderClient.cs
@@ -54,9 +54,7 @@ namespace Picturepark.SDK.V1.ServiceProvider
             // buffer
             _liveStreamBuffer.BufferHoldBackTimeMilliseconds = delayMilliseconds;
 
-#pragma warning disable CS0618 // Type or member is obsolete
             var queueName = $"{DefaultExchangeName}.{_configuration.NodeId}";
-#pragma warning restore CS0618 // Type or member is obsolete
             var isUnprotectedProvider = TryDeclareExchangeAndBindQueue(queueName);
             if (!isUnprotectedProvider)
             {


### PR DESCRIPTION
…nfiguration.NodeId: it is still required until queue infrastructure has been migrated