### PR TITLE
Bugfix/pp9 21396 11.13 metadatastatus compatibility

### DIFF
--- a/src/Picturepark.SDK.V1.Tests/Clients/LiveStreamTests.cs
+++ b/src/Picturepark.SDK.V1.Tests/Clients/LiveStreamTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Picturepark.SDK.V1.Contract;
@@ -24,23 +25,26 @@ namespace Picturepark.SDK.V1.Tests.Clients
         {
             // Arrange
             var time = DateTime.Now;
-            await _fixture.Users.Create();
+            var createdUser = await _fixture.Users.Create();
 
             var request = new LiveStreamSearchRequest
             {
                 Limit = 10,
-                From = time,
+                From = time - TimeSpan.FromSeconds(10), // handle potential clock skew
                 ScopeType = "DocumentChange"
             };
 
             // Give some time for the live stream event to be processed
-            await Task.Delay(TimeSpan.FromSeconds(5));
+            await Task.Delay(TimeSpan.FromSeconds(10));
 
             // Act
             var result = await _client.LiveStream.SearchAsync(request);
 
             // Assert
             result.Results.Should().NotBeEmpty();
+
+            var livestreamMessages = result.Results.Select(r => LiveStreamMessage.FromJson(r.Document));
+            livestreamMessages.Select(m => m.DocumentChange.DocumentId).Should().Contain(createdUser.Id);
         }
     }
 }

--- a/src/Picturepark.SDK.V1/Compatibility/Cp1113BackwardsCompatibleMetadataClient.cs
+++ b/src/Picturepark.SDK.V1/Compatibility/Cp1113BackwardsCompatibleMetadataClient.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Picturepark.SDK.V1.Contract;
+
+namespace Picturepark.SDK.V1.Compatibility;
+
+internal sealed class Cp1113BackwardsCompatibleMetadataClient : IMetadataClient
+{
+    private readonly IMetadataClient _metadataClientImplementation;
+
+    public Cp1113BackwardsCompatibleMetadataClient(IMetadataClient metadataClientImplementation)
+    {
+        _metadataClientImplementation = metadataClientImplementation;
+    }
+
+#pragma warning disable CS0618 // Type or member is obsolete
+    public async Task<MetadataStatus> GetStatusAsync(CancellationToken cancellationToken = default)
+    {
+        var status = await _metadataClientImplementation.GetStatusAsync(cancellationToken);
+
+        if (status.ListSchemaIds is not null && status.ContentOrLayerSchemaIds is not null)
+        {
+            status.MainDocuments ??= new MetadataStatusEntries
+            {
+                ListSchemaIds = status.ListSchemaIds,
+                ContentOrLayerSchemaIds = status.ContentOrLayerSchemaIds
+            };
+        }
+
+        status.SearchDocuments ??= new MetadataStatusEntries
+        {
+            ListSchemaIds = Array.Empty<string>(),
+            ContentOrLayerSchemaIds = Array.Empty<string>()
+        };
+
+        return status;
+    }
+#pragma warning restore CS0618 // Type or member is obsolete
+
+    public async Task<BusinessProcess> UpdateOutdatedAsync(CancellationToken cancellationToken = default)
+    {
+        return await _metadataClientImplementation.UpdateOutdatedAsync(cancellationToken);
+    }
+}

--- a/src/Picturepark.SDK.V1/PictureparkService.cs
+++ b/src/Picturepark.SDK.V1/PictureparkService.cs
@@ -3,6 +3,7 @@ using Picturepark.SDK.V1.Contract;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Reflection;
+using Picturepark.SDK.V1.Compatibility;
 using Picturepark.SDK.V1.Partial;
 
 namespace Picturepark.SDK.V1
@@ -121,7 +122,7 @@ namespace Picturepark.SDK.V1
             BusinessRule = new BusinessRuleClient(settings, httpClient);
             OutputFormat = new OutputFormatClient(BusinessProcess, settings, httpClient);
             DisplayValue = new DisplayValueClient(settings, httpClient);
-            Metadata = new MetadataClient(settings, httpClient);
+            Metadata = new Cp1113BackwardsCompatibleMetadataClient(new MetadataClient(settings, httpClient));
             IdentityProvider = new IdentityProviderClient(settings, httpClient);
             XmpMapping = new XmpMappingClient(settings, httpClient);
             Notification = new NotificationClient(settings, httpClient);


### PR DESCRIPTION
without `Cp1113BackwardsCompatibleMetadataClient`, a user who already switches to the new properties would run into NRE due to the fields not yet being returned by CP 11.13.