### PR TITLE
ServiceProviders: deprecate NodeId

### DIFF
--- a/src/Picturepark.SDK.V1.ServiceProvider/Common/Configuration.cs
+++ b/src/Picturepark.SDK.V1.ServiceProvider/Common/Configuration.cs
@@ -27,6 +27,7 @@ namespace Picturepark.SDK.V1.ServiceProvider
 
         public string ServiceProviderId { get; set; }
 
+        [Obsolete("NodeId will be removed in a future release")]
         public string NodeId { get; set; }
 
         public JsonSerializerSettings SerializerSettings { get; set; }

--- a/src/Picturepark.SDK.V1.ServiceProvider/ServiceProviderClient.cs
+++ b/src/Picturepark.SDK.V1.ServiceProvider/ServiceProviderClient.cs
@@ -54,7 +54,9 @@ namespace Picturepark.SDK.V1.ServiceProvider
             // buffer
             _liveStreamBuffer.BufferHoldBackTimeMilliseconds = delayMilliseconds;
 
+#pragma warning disable CS0618 // Type or member is obsolete
             var queueName = $"{DefaultExchangeName}.{_configuration.NodeId}";
+#pragma warning restore CS0618 // Type or member is obsolete
             var isUnprotectedProvider = TryDeclareExchangeAndBindQueue(queueName);
             if (!isUnprotectedProvider)
             {


### PR DESCRIPTION
Since all ServiceProviders have been updated to the new queue configuration, `NodeId` is no longer required

This reverts commit d4e3d5f382fed7b915c2d7973c868b298bdfa36d.