### PR TITLE
PP9-20679 Upgrade RabbitMQ.Client package to 7.1

### DIFF
--- a/src/Picturepark.SDK.V1.ServiceProvider/Buffer/EventArgsLiveStreamMessage.cs
+++ b/src/Picturepark.SDK.V1.ServiceProvider/Buffer/EventArgsLiveStreamMessage.cs
@@ -1,6 +1,7 @@
 ﻿using Picturepark.SDK.V1.Contract;
 using RabbitMQ.Client;
 using System;
+using System.Threading.Tasks;
 
 namespace Picturepark.SDK.V1.ServiceProvider.Buffer
 {
@@ -12,18 +13,18 @@ namespace Picturepark.SDK.V1.ServiceProvider.Buffer
 
         public LiveStreamMessage Message { get; set; }
 
-        public IModel Model { get; set; }
+        public IChannel Channel { get; set; }
 
         public ulong Tag { get; set; }
 
-        public void Ack()
+        public async Task Ack()
         {
-            Model.BasicAck(Tag, false);
+            await Channel.BasicAckAsync(Tag, false);
         }
 
-        public void Nack(bool requeue = false)
+        public async Task Nack(bool requeue = false)
         {
-            Model.BasicNack(Tag, false, requeue);
+            await Channel.BasicNackAsync(Tag, false, requeue);
         }
     }
 }

--- a/src/Picturepark.SDK.V1.ServiceProvider/Buffer/LiveStreamConsumer.cs
+++ b/src/Picturepark.SDK.V1.ServiceProvider/Buffer/LiveStreamConsumer.cs
@@ -9,12 +9,12 @@ namespace Picturepark.SDK.V1.ServiceProvider.Buffer
     public class LiveStreamConsumer
     {
         private readonly Configuration _configuration;
-        private readonly IModel _model;
+        private readonly IChannel _channel;
 
-        public LiveStreamConsumer(Configuration configuration, IModel model)
+        public LiveStreamConsumer(Configuration configuration, IChannel channel)
         {
             _configuration = configuration;
-            _model = model;
+            _channel = channel;
         }
 
         public event EventHandler<EventArgsLiveStreamMessage> Received;
@@ -31,7 +31,7 @@ namespace Picturepark.SDK.V1.ServiceProvider.Buffer
                 Created = message.Timestamp,
                 Received = DateTime.Now,
                 Message = message,
-                Model = _model,
+                Channel = _channel,
                 Tag = e.DeliveryTag
             };
 

--- a/src/Picturepark.SDK.V1.ServiceProvider/Picturepark.SDK.V1.ServiceProvider.csproj
+++ b/src/Picturepark.SDK.V1.ServiceProvider/Picturepark.SDK.V1.ServiceProvider.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="RabbitMQ.Client" Version="7.0.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="7.1.0" />
     <PackageReference Include="System.Reactive.Linq" Version="6.0.1" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.7.115">
       <PrivateAssets>All</PrivateAssets>

--- a/src/Picturepark.SDK.V1.ServiceProvider/Picturepark.SDK.V1.ServiceProvider.csproj
+++ b/src/Picturepark.SDK.V1.ServiceProvider/Picturepark.SDK.V1.ServiceProvider.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="RabbitMQ.Client" Version="6.8.1" />
+    <PackageReference Include="RabbitMQ.Client" Version="7.0.0" />
     <PackageReference Include="System.Reactive.Linq" Version="6.0.1" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.7.115">
       <PrivateAssets>All</PrivateAssets>

--- a/src/Picturepark.SDK.V1.ServiceProvider/ServiceProviderClient.cs
+++ b/src/Picturepark.SDK.V1.ServiceProvider/ServiceProviderClient.cs
@@ -7,11 +7,13 @@ using System.Reactive;
 using System.Reactive.Linq;
 using System.Net.Security;
 using System.Security.Authentication;
+using System.Threading;
+using System.Threading.Tasks;
 using RabbitMQ.Client.Exceptions;
 
 namespace Picturepark.SDK.V1.ServiceProvider
 {
-    public class ServiceProviderClient : IDisposable
+    public class ServiceProviderClient : IAsyncDisposable
     {
         private const string DefaultExchangeName = "pp.livestream";
         private const string DefaultQueueName = "pp.livestream.messages";
@@ -19,10 +21,11 @@ namespace Picturepark.SDK.V1.ServiceProvider
         private readonly Configuration _configuration;
         private readonly ConnectionFactory _factory;
         private readonly LiveStreamBuffer _liveStreamBuffer;
+        private readonly Task _initializeTask;
 
         private IConnection _connection;
-        private IModel _liveStreamModel;
-        private IModel _requestMessageModel;
+        private IChannel _liveStreamChannel;
+        private IChannel _requestMessageChannel;
 
         private LiveStreamConsumer _liveStreamConsumer;
 
@@ -32,41 +35,37 @@ namespace Picturepark.SDK.V1.ServiceProvider
 
             _factory = CreateConnectionFactory(configuration);
 
-            _connection = _factory.CreateConnection();
-            _liveStreamModel = _connection.CreateModel();
-            _requestMessageModel = _connection.CreateModel();
-
+            _initializeTask = ConnectAsync(CancellationToken.None);
             _liveStreamBuffer = new LiveStreamBuffer(new LiveStreamBufferPriorityQueue());
             _liveStreamBuffer.Start();
         }
 
-        public void Dispose()
+        public async ValueTask DisposeAsync()
         {
-            ////_liveStreamConsumer.Stop();
-            _liveStreamModel.Close();
-            _requestMessageModel.Close();
+            await _liveStreamChannel.CloseAsync();
+            await _requestMessageChannel.CloseAsync();
             _liveStreamBuffer.Stop();
-            _connection.Close();
+            await _connection.CloseAsync();
         }
 
-        public IObservable<EventPattern<EventArgsLiveStreamMessage>> GetLiveStreamObserver(int bufferSize = 0, int delayMilliseconds = 0)
+        public async Task<IObservable<EventPattern<EventArgsLiveStreamMessage>>> GetLiveStreamObserver(int bufferSize = 0, int delayMilliseconds = 0, CancellationToken cancellationToken = default)
         {
+            await _initializeTask; // maybe better to start the task here instead, and pass the cancellation token
+
             // buffer
             _liveStreamBuffer.BufferHoldBackTimeMilliseconds = delayMilliseconds;
 
 #pragma warning disable CS0618 // Type or member is obsolete
             var queueName = $"{DefaultExchangeName}.{_configuration.NodeId}";
 #pragma warning restore CS0618 // Type or member is obsolete
-            var isUnprotectedProvider = TryDeclareExchangeAndBindQueue(queueName);
+            var isUnprotectedProvider = await TryDeclareExchangeAndBindQueue(queueName, cancellationToken);
             if (!isUnprotectedProvider)
             {
-                _connection = _factory.CreateConnection();
-                _liveStreamModel = _connection.CreateModel();
-                _requestMessageModel = _connection.CreateModel();
+                await ConnectAsync(cancellationToken);
                 queueName = DefaultQueueName;
             }
 
-            _liveStreamModel.BasicQos(0, (ushort)bufferSize, false);
+            await _liveStreamChannel.BasicQosAsync(0, (ushort)bufferSize, false, cancellationToken);
 
             // create observable
             var result = Observable.FromEventPattern<EventArgsLiveStreamMessage>(
@@ -75,34 +74,45 @@ namespace Picturepark.SDK.V1.ServiceProvider
             );
 
             // create consumer for RabbitMQ events
-            _liveStreamConsumer = new LiveStreamConsumer(_configuration, _liveStreamModel);
+            _liveStreamConsumer = new LiveStreamConsumer(_configuration, _liveStreamChannel);
             _liveStreamConsumer.Received += (_, e) => { _liveStreamBuffer.Enqueue(e); };
 
             // consumer
-            var consumer = new EventingBasicConsumer(_requestMessageModel);
-            consumer.Received += (o, e) => { _liveStreamConsumer.OnReceived(o, e); };
-            _liveStreamModel.BasicConsume(queue: queueName, autoAck: false, consumer: consumer);
+            var consumer = new AsyncEventingBasicConsumer(_requestMessageChannel);
+            consumer.ReceivedAsync += (o, e) =>
+            {
+                _liveStreamConsumer.OnReceived(o, e);
+                return Task.CompletedTask;
+            };
+            await _liveStreamChannel.BasicConsumeAsync(queue: queueName, autoAck: false, consumer: consumer, cancellationToken);
 
             return result;
         }
 
-        private bool TryDeclareExchangeAndBindQueue(string queueName)
+        private async Task<bool> TryDeclareExchangeAndBindQueue(string queueName, CancellationToken cancellationToken)
         {
             try
             {
-                _liveStreamModel.ExchangeDeclare(DefaultExchangeName, ExchangeType.Fanout);
+                await _liveStreamChannel.ExchangeDeclareAsync(DefaultExchangeName, ExchangeType.Fanout, cancellationToken: cancellationToken);
 
                 var args = new Dictionary<string, object> { { "x-max-priority", _configuration.DefaultQueuePriorityMax } };
 
                 // queue
-                var queueDeclareOk = _liveStreamModel.QueueDeclare(queueName, true, false, false, args);
-                _liveStreamModel.QueueBind(queueDeclareOk, DefaultExchangeName, string.Empty, null);
+                var queueDeclareOk = await _liveStreamChannel.QueueDeclareAsync(queueName, true, false, false, args, cancellationToken: cancellationToken);
+                await _liveStreamChannel.QueueBindAsync(queueDeclareOk, DefaultExchangeName, string.Empty, null, cancellationToken: cancellationToken);
                 return true;
             }
             catch (OperationInterruptedException ex) when (ex.ShutdownReason.ReplyCode == 403)
             {
                 return false;
             }
+        }
+
+        private async Task ConnectAsync(CancellationToken cancellationToken)
+        {
+            _connection = await _factory.CreateConnectionAsync(cancellationToken);
+            _liveStreamChannel = await _connection.CreateChannelAsync(cancellationToken: cancellationToken);
+            _requestMessageChannel = await _connection.CreateChannelAsync(cancellationToken: cancellationToken);
         }
 
         private ConnectionFactory CreateConnectionFactory(Configuration configuration)

--- a/src/Picturepark.SDK.V1.ServiceProvider/ServiceProviderClient.cs
+++ b/src/Picturepark.SDK.V1.ServiceProvider/ServiceProviderClient.cs
@@ -21,7 +21,6 @@ namespace Picturepark.SDK.V1.ServiceProvider
         private readonly Configuration _configuration;
         private readonly ConnectionFactory _factory;
         private readonly LiveStreamBuffer _liveStreamBuffer;
-        private readonly Task _initializeTask;
 
         private IConnection _connection;
         private IChannel _liveStreamChannel;
@@ -35,7 +34,6 @@ namespace Picturepark.SDK.V1.ServiceProvider
 
             _factory = CreateConnectionFactory(configuration);
 
-            _initializeTask = ConnectAsync(CancellationToken.None);
             _liveStreamBuffer = new LiveStreamBuffer(new LiveStreamBufferPriorityQueue());
             _liveStreamBuffer.Start();
         }
@@ -48,22 +46,15 @@ namespace Picturepark.SDK.V1.ServiceProvider
             await _connection.CloseAsync();
         }
 
-        public async Task<IObservable<EventPattern<EventArgsLiveStreamMessage>>> GetLiveStreamObserver(int bufferSize = 0, int delayMilliseconds = 0, CancellationToken cancellationToken = default)
+        public async Task<IObservable<EventPattern<EventArgsLiveStreamMessage>>> GetLiveStreamObserver(
+            int bufferSize = 0, int delayMilliseconds = 0, CancellationToken cancellationToken = default)
         {
-            await _initializeTask; // maybe better to start the task here instead, and pass the cancellation token
-
             // buffer
             _liveStreamBuffer.BufferHoldBackTimeMilliseconds = delayMilliseconds;
 
-#pragma warning disable CS0618 // Type or member is obsolete
-            var queueName = $"{DefaultExchangeName}.{_configuration.NodeId}";
-#pragma warning restore CS0618 // Type or member is obsolete
-            var isUnprotectedProvider = await TryDeclareExchangeAndBindQueue(queueName, cancellationToken);
-            if (!isUnprotectedProvider)
-            {
-                await ConnectAsync(cancellationToken);
-                queueName = DefaultQueueName;
-            }
+            _connection = await _factory.CreateConnectionAsync(cancellationToken);
+            _liveStreamChannel = await _connection.CreateChannelAsync(cancellationToken: cancellationToken);
+            _requestMessageChannel = await _connection.CreateChannelAsync(cancellationToken: cancellationToken);
 
             await _liveStreamChannel.BasicQosAsync(0, (ushort)bufferSize, false, cancellationToken);
 
@@ -84,35 +75,9 @@ namespace Picturepark.SDK.V1.ServiceProvider
                 _liveStreamConsumer.OnReceived(o, e);
                 return Task.CompletedTask;
             };
-            await _liveStreamChannel.BasicConsumeAsync(queue: queueName, autoAck: false, consumer: consumer, cancellationToken);
+            await _liveStreamChannel.BasicConsumeAsync(queue: DefaultQueueName, autoAck: false, consumer: consumer, cancellationToken);
 
             return result;
-        }
-
-        private async Task<bool> TryDeclareExchangeAndBindQueue(string queueName, CancellationToken cancellationToken)
-        {
-            try
-            {
-                await _liveStreamChannel.ExchangeDeclareAsync(DefaultExchangeName, ExchangeType.Fanout, cancellationToken: cancellationToken);
-
-                var args = new Dictionary<string, object> { { "x-max-priority", _configuration.DefaultQueuePriorityMax } };
-
-                // queue
-                var queueDeclareOk = await _liveStreamChannel.QueueDeclareAsync(queueName, true, false, false, args, cancellationToken: cancellationToken);
-                await _liveStreamChannel.QueueBindAsync(queueDeclareOk, DefaultExchangeName, string.Empty, null, cancellationToken: cancellationToken);
-                return true;
-            }
-            catch (OperationInterruptedException ex) when (ex.ShutdownReason.ReplyCode == 403)
-            {
-                return false;
-            }
-        }
-
-        private async Task ConnectAsync(CancellationToken cancellationToken)
-        {
-            _connection = await _factory.CreateConnectionAsync(cancellationToken);
-            _liveStreamChannel = await _connection.CreateChannelAsync(cancellationToken: cancellationToken);
-            _requestMessageChannel = await _connection.CreateChannelAsync(cancellationToken: cancellationToken);
         }
 
         private ConnectionFactory CreateConnectionFactory(Configuration configuration)
@@ -135,7 +100,8 @@ namespace Picturepark.SDK.V1.ServiceProvider
                     Version = SslProtocols.Tls12,
                     Enabled = true,
                     ServerName = factory.HostName,
-                    AcceptablePolicyErrors = SslPolicyErrors.RemoteCertificateNameMismatch | SslPolicyErrors.RemoteCertificateChainErrors
+                    AcceptablePolicyErrors = SslPolicyErrors.RemoteCertificateNameMismatch |
+                                             SslPolicyErrors.RemoteCertificateChainErrors
                 };
             }
 

--- a/src/Picturepark.SDK.V1.Tests/Clients/LiveStreamTests.cs
+++ b/src/Picturepark.SDK.V1.Tests/Clients/LiveStreamTests.cs
@@ -24,18 +24,18 @@ namespace Picturepark.SDK.V1.Tests.Clients
         public async Task ShouldReturnSearchResultsCorrectly()
         {
             // Arrange
-            var time = DateTime.Now;
             var createdUser = await _fixture.Users.Create();
 
             var request = new LiveStreamSearchRequest
             {
-                Limit = 100,
-                From = time - TimeSpan.FromSeconds(10), // handle potential clock skew
-                ScopeType = "DocumentChange"
+                Limit = 1000,
+                From = createdUser.Audit.ModificationDate.AddSeconds(-5),
+                To = createdUser.Audit.ModificationDate.AddSeconds(5),
+                ScopeType = "DocumentChange",
             };
 
             // Give some time for the live stream event to be processed
-            await Task.Delay(TimeSpan.FromSeconds(10));
+            await Task.Delay(TimeSpan.FromSeconds(20));
 
             // Act
             var result = await _client.LiveStream.SearchAsync(request);


### PR DESCRIPTION
This update involves a change to the ServiceProviderClient, whose methods are now async. This is due to the fact that the RabbitMQ.Client package was changed to also be fully async in version 7.0, removing the synchronous APIs we were using up until now.